### PR TITLE
Fix default gazebo versions for galactic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,39 +11,16 @@ find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(ros_ign_bridge REQUIRED)
 
-# Edifice
-if(("$ENV{GZ_VERSION}" STREQUAL "edifice") OR ("$ENV{IGNITION_VERSION}" STREQUAL "edifice"))
-  find_package(ignition-transport10 REQUIRED)
-  set(GZ_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
-
-  find_package(ignition-msgs7 REQUIRED)
-  set(GZ_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
-
-  set(GZ_TARGET_PREFIX ignition)
-
-  message(STATUS "Compiling against Ignition Edifice")
-# Garden
-elseif(("$ENV{GZ_VERSION}" STREQUAL "garden") OR ("$ENV{IGNITION_VERSION}" STREQUAL "garden"))
-  find_package(gz-transport12 REQUIRED)
-  set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
-
-  find_package(gz-msgs9 REQUIRED)
-  set(GZ_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
-
-  set(GZ_TARGET_PREFIX gz)
-
-  message(STATUS "Compiling against Gazebo Garden")
-# Default to Fortress
-else()
+# Fortress
+if("$ENV{GZ_VERSION}" STREQUAL "fortress")
   find_package(ignition-transport11 REQUIRED)
   set(GZ_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
-
-  find_package(ignition-msgs8 REQUIRED)
-  set(GZ_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
-
-  set(GZ_TARGET_PREFIX ignition)
-
   message(STATUS "Compiling against Ignition Fortress")
+# Edifice (default)
+else()
+  find_package(ignition-transport10 REQUIRED)
+  set(GZ_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
+  message(STATUS "Compiling against Ignition Edifice")
 endif()
 
 add_library(${PROJECT_NAME} SHARED
@@ -57,7 +34,7 @@ ament_target_dependencies(${PROJECT_NAME}
   ros_ign_bridge)
 
 target_link_libraries(${PROJECT_NAME}
-  ${GZ_TARGET_PREFIX}-transport${GZ_TRANSPORT_VER}::core)
+  ignition-transport${GZ_TRANSPORT_VER}::core)
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/package.xml
+++ b/package.xml
@@ -16,17 +16,11 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>ros_ign_bridge</depend>
 
-  <!-- Garden -->
-  <depend condition="$GZ_VERSION == garden or $IGNITION_VERSION == garden">gz-msgs9</depend>
-  <depend condition="$GZ_VERSION == garden or $IGNITION_VERSION == garden">gz-transport12</depend>
-  <!-- Fortress (default) -->
-  <depend condition="$GZ_VERSION == fortress or $IGNITION_VERSION == fortress">ignition-msgs8</depend>
-  <depend condition="$GZ_VERSION == fortress or $IGNITION_VERSION == fortress">ignition-transport11</depend>
-  <depend condition="$GZ_VERSION == '' and $IGNITION_VERSION == ''">ignition-msgs8</depend>
-  <depend condition="$GZ_VERSION == '' and $IGNITION_VERSION == ''">ignition-transport11</depend>
-  <!-- Edifice -->
-  <depend condition="$GZ_VERSION == edifice or $IGNITION_VERSION == edifice">ignition-msgs7</depend>
-  <depend condition="$GZ_VERSION == edifice or $IGNITION_VERSION == edifice">ignition-transport10</depend>
+  <!-- Fortress -->
+  <depend condition="$GZ_VERSION == fortress">ignition-transport11</depend>
+  <!-- Edifice (default) -->
+  <depend condition="$GZ_VERSION == edifice">ignition-transport10</depend>
+  <depend condition="$GZ_VERSION == ''">ignition-transport10</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
The default gazebo version was incorrect. This fixes rthe default gazebo versions, and removes unneeded dependencies. There is no need to handle ``IGNITION_VERSION``, because we never ask the user to set this environment variable. We tell them to set ``GZ_VERSION`` instead.