### PR TITLE
Simplify package.xml and CMakeListst.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,34 +12,25 @@ find_package(pluginlib REQUIRED)
 find_package(ros_gz_bridge REQUIRED)
 
 # Edifice
-if(("$ENV{GZ_VERSION}" STREQUAL "edifice") OR ("$ENV{IGNITION_VERSION}" STREQUAL "edifice"))
+if("$ENV{GZ_VERSION}" STREQUAL "edifice")
   find_package(ignition-transport10 REQUIRED)
   set(GZ_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
-
-  find_package(ignition-msgs7 REQUIRED)
-  set(GZ_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
 
   set(GZ_TARGET_PREFIX ignition)
 
   message(STATUS "Compiling against Ignition Edifice")
 # Garden
-elseif(("$ENV{GZ_VERSION}" STREQUAL "garden") OR ("$ENV{IGNITION_VERSION}" STREQUAL "garden"))
+elseif("$ENV{GZ_VERSION}" STREQUAL "garden")
   find_package(gz-transport12 REQUIRED)
   set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
-
-  find_package(gz-msgs9 REQUIRED)
-  set(GZ_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
 
   set(GZ_TARGET_PREFIX gz)
 
   message(STATUS "Compiling against Gazebo Garden")
-# Default to Fortress
+# Fortress (Default)
 else()
   find_package(ignition-transport11 REQUIRED)
   set(GZ_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
-
-  find_package(ignition-msgs8 REQUIRED)
-  set(GZ_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
 
   set(GZ_TARGET_PREFIX ignition)
 

--- a/package.xml
+++ b/package.xml
@@ -17,16 +17,12 @@
   <depend>ros_gz_bridge</depend>
 
   <!-- Garden -->
-  <depend condition="$GZ_VERSION == garden or $IGNITION_VERSION == garden">gz-msgs9</depend>
-  <depend condition="$GZ_VERSION == garden or $IGNITION_VERSION == garden">gz-transport12</depend>
+  <depend condition="$GZ_VERSION == garden">gz-transport12</depend>
   <!-- Fortress (default) -->
-  <depend condition="$GZ_VERSION == fortress or $IGNITION_VERSION == fortress">ignition-msgs8</depend>
-  <depend condition="$GZ_VERSION == fortress or $IGNITION_VERSION == fortress">ignition-transport11</depend>
-  <depend condition="$GZ_VERSION == '' and $IGNITION_VERSION == ''">ignition-msgs8</depend>
-  <depend condition="$GZ_VERSION == '' and $IGNITION_VERSION == ''">ignition-transport11</depend>
+  <depend condition="$GZ_VERSION == fortress">ignition-transport11</depend>
+  <depend condition="$GZ_VERSION == ''">ignition-transport11</depend>
   <!-- Edifice -->
-  <depend condition="$GZ_VERSION == edifice or $IGNITION_VERSION == edifice">ignition-msgs7</depend>
-  <depend condition="$GZ_VERSION == edifice or $IGNITION_VERSION == edifice">ignition-transport10</depend>
+  <depend condition="$GZ_VERSION == edifice">ignition-transport10</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Removes possibility of using the ``IGNITION_VERSION`` env variable as a replacement of ``GZ_VERSION``, which should be used. Removes unnecessary dependencies.